### PR TITLE
Allow Success Datadog Event Action

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -68,10 +68,10 @@ export const parseEventAlertType = (s: string): v1.EventAlertType | undefined =>
   if (!s) {
     return undefined
   }
-  if (s === 'error' || s === 'warning' || s === 'info') {
+  if (s === 'error' || s === 'warning' || s === 'info' || s === 'success') {
     return s
   }
-  throw new Error(`event-alert-type must be either 'error', 'warning', or 'info'`)
+  throw new Error(`event-alert-type must be either 'error', 'warning', 'success' or 'info'`)
 }
 
 const sendEvent = async (api: v1.EventsApi, inputs: EventInputs) => {


### PR DESCRIPTION
Right now we only allow 3 different event types:
- error
- warning
- info

We need the `success` event type also since we use this to send a Datadog Event whenever a deploy is done, so when it succeeds, we want to show that it was a success.

closes #360

I've done some testing already and it seems to work (I forked the repo and tested it from there).