### PR TITLE
Split csv metrics if too long

### DIFF
--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -51,6 +51,16 @@ describe('parseMetricsCsvUseHeaderTags', () => {
 
 describe('splitArrayToChunks', () => {
   it('splits an array into chunks of a given size', () => {
+    const array = [1, 2, 3, 4, 5, 6]
+    const chunkSize = 3
+    const result = splitArrayToChunks(array, chunkSize)
+    expect(result).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ])
+  })
+
+  it('splits an array into chunks of a given size with remainder', () => {
     const array = [1, 2, 3, 4, 5]
     const chunkSize = 2
     const result = splitArrayToChunks(array, chunkSize)

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseMetricsCsvSimple, parseMetricsCsvUseHeaderTags } from '../src/csv.js'
+import { parseMetricsCsvSimple, parseMetricsCsvUseHeaderTags, splitArrayToChunks } from '../src/csv.js'
 
 describe('parseMetricsCsvSimple', () => {
   it('parses the metrics csv', async () => {
@@ -46,5 +46,28 @@ describe('parseMetricsCsvUseHeaderTags', () => {
         tags: ['service:frontend', 'env:development'],
       },
     ])
+  })
+})
+
+describe('splitArrayToChunks', () => {
+  it('splits an array into chunks of a given size', () => {
+    const array = [1, 2, 3, 4, 5]
+    const chunkSize = 2
+    const result = splitArrayToChunks(array, chunkSize)
+    expect(result).toEqual([[1, 2], [3, 4], [5]])
+  })
+
+  it('returns an empty array when the input array is empty', () => {
+    const array: number[] = []
+    const chunkSize = 2
+    const result = splitArrayToChunks(array, chunkSize)
+    expect(result).toEqual([])
+  })
+
+  it('returns the original array when the chunk size is greater than the array length', () => {
+    const array = [1, 2, 3]
+    const chunkSize = 5
+    const result = splitArrayToChunks(array, chunkSize)
+    expect(result).toEqual([[1, 2, 3]])
   })
 })


### PR DESCRIPTION
## Problem to solve
When the given metrics are too long, Datadog API returns `413 Payload too long`.
